### PR TITLE
ITC-3533 Check for missing service templates. This could happen if a …

### DIFF
--- a/src/app/modules/checkmk_module/pages/mkchecks/mkchecks-index/mkchecks-index.component.html
+++ b/src/app/modules/checkmk_module/pages/mkchecks/mkchecks-index/mkchecks-index.component.html
@@ -158,13 +158,20 @@
                     </td>
                     <td>{{ mkcheck.name }}</td>
                     <td>
-                        <oitc-label-link
-                            [objectId]="mkcheck.servicetemplate.id"
-                            [route]="'/servicetemplates/edit'"
-                            [permissions]="'servicetemplates.edit'"
-                        >
-                            {{ mkcheck.servicetemplate.template_name }}
-                        </oitc-label-link>
+                        @if (mkcheck.servicetemplate) {
+                            <oitc-label-link
+                                [objectId]="mkcheck.servicetemplate.id"
+                                [route]="'/servicetemplates/edit'"
+                                [permissions]="'servicetemplates.edit'"
+                            >
+                                {{ mkcheck.servicetemplate.template_name }}
+                            </oitc-label-link>
+                        } @else {
+                            <span class="italic text-secondary">
+                                <!-- this was a bug until ITC-3533 -->
+                                {{ t('No service template assignment defined') }}
+                            </span>
+                        }
                     </td>
 
                     <td class="width-50">

--- a/src/app/modules/checkmk_module/pages/mkchecks/mkchecks.interface.ts
+++ b/src/app/modules/checkmk_module/pages/mkchecks/mkchecks.interface.ts
@@ -37,7 +37,7 @@ export interface Mkcheck {
     servicetemplate_id: number
     created: string
     modified: string
-    servicetemplate: ServicetemplateEntity
+    servicetemplate: ServicetemplateEntity | null
 }
 
 /**********************


### PR DESCRIPTION
…service template got deleted but the MKCheck is still defined due to a missing dependent: true in the backend code