### PR TITLE
ITC-3680 - Update to Angular 21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
                 "ngx-color-picker": "^20.1.1",
                 "ngx-cookie-service": "^21.1.0",
                 "ngx-echarts": "^21.0.0",
-                "ngx-resize-observer": "^3.2.0",
+                "ngx-resize-observer": "^3.3.0",
                 "ngx-scrollbar": "^19.1.1",
                 "ngx-toastr": "^19.1.0",
                 "prettier": "^3.7.4",
@@ -10656,16 +10656,16 @@
             }
         },
         "node_modules/ngx-resize-observer": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/ngx-resize-observer/-/ngx-resize-observer-3.2.0.tgz",
-            "integrity": "sha512-ODJnHbyvutVk7MY2ApfHlwJFs/VpIb9CyPwP1uPHD5Eq6eT7nsObCcUd/JZWLPxXqz4f6JYQjRPrDwDLZXLzaw==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/ngx-resize-observer/-/ngx-resize-observer-3.3.0.tgz",
+            "integrity": "sha512-LbK27lsQJOS5sfPnvQ7Sa4l92w/C+Oo6nsXXsK6dJ5USTC/xyPdwYGjkEDAM01PDMkooaIeGJEeKusksQE/5Wg==",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.3.0"
             },
             "peerDependencies": {
-                "@angular/common": "^20.0.0",
-                "@angular/core": "^20.0.0"
+                "@angular/common": "^21.0.0",
+                "@angular/core": "^21.0.0"
             }
         },
         "node_modules/ngx-scrollbar": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
         "ngx-color-picker": "^20.1.1",
         "ngx-cookie-service": "^21.1.0",
         "ngx-echarts": "^21.0.0",
-        "ngx-resize-observer": "^3.2.0",
+        "ngx-resize-observer": "^3.3.0",
         "ngx-scrollbar": "^19.1.1",
         "ngx-toastr": "^19.1.0",
         "prettier": "^3.7.4",
@@ -102,10 +102,6 @@
         "@rollup/rollup-linux-arm64-gnu": "^4.55.1"
     },
     "overrides": {
-        "ngx-resize-observer": {
-            "@angular/core": "21.0.8",
-            "@angular/common": "21.0.8"
-        },
         "sass": "^1.97.0"
     },
     "devDependencies": {


### PR DESCRIPTION
* Upgrade ngx-resize-observer from 3.2.0 to 3.3.0
* Remove the override dependency to older angular version