### PR TITLE
ITC-3703 - DistributeModule: Satellites add|edit - show server timezone and current server time 

### DIFF
--- a/src/app/modules/distribute_module/pages/satellites/satellites-add/satellites-add.component.ts
+++ b/src/app/modules/distribute_module/pages/satellites/satellites-add/satellites-add.component.ts
@@ -147,6 +147,8 @@ export class SatellitesAddComponent implements OnDestroy, OnInit {
     private getUserTimezone() {
         this.subscriptions.add(this.TimezoneService.getTimezoneConfiguration().subscribe(data => {
             this.post.Satellite.timezone = data.user_timezone;
+            this.serverTimeZone = data.server_timezone;
+            this.serverTime = data.server_time;
             this.cdr.markForCheck();
         }));
     }

--- a/src/app/modules/distribute_module/pages/satellites/satellites-edit/satellites-edit.component.ts
+++ b/src/app/modules/distribute_module/pages/satellites/satellites-edit/satellites-edit.component.ts
@@ -151,6 +151,8 @@ export class SatellitesEditComponent implements OnDestroy, OnInit {
     private getUserTimezone() {
         this.subscriptions.add(this.TimezoneService.getTimezoneConfiguration().subscribe(data => {
             this.post.Satellite.timezone = data.user_timezone;
+            this.serverTimeZone = data.server_timezone;
+            this.serverTime = data.server_time;
             this.cdr.markForCheck();
         }));
     }

--- a/src/app/modules/distribute_module/pages/satellites/satellites-edit/satellites-edit.component.ts
+++ b/src/app/modules/distribute_module/pages/satellites/satellites-edit/satellites-edit.component.ts
@@ -183,7 +183,7 @@ export class SatellitesEditComponent implements OnDestroy, OnInit {
                 }
 
                 this.post.protocol = 'https';
-                if (this.post.Satellite.url.startsWith('http://')) {
+                if (this.post.Satellite.url?.startsWith('http://')) {
                     this.post.protocol = 'http';
                 }
                 this.post.proxyProtocol = 'https';

--- a/src/app/modules/distribute_module/pages/satellites/satellites-edit/satellites-edit.component.ts
+++ b/src/app/modules/distribute_module/pages/satellites/satellites-edit/satellites-edit.component.ts
@@ -187,7 +187,7 @@ export class SatellitesEditComponent implements OnDestroy, OnInit {
                     this.post.protocol = 'http';
                 }
                 this.post.proxyProtocol = 'https';
-                if (this.post.Satellite.proxy_url.startsWith('http://')) {
+                if (this.post.Satellite.proxy_url?.startsWith('http://')) {
                     this.post.proxyProtocol = 'http';
                 }
 

--- a/src/app/modules/distribute_module/pages/satellites/satellites.interface.ts
+++ b/src/app/modules/distribute_module/pages/satellites/satellites.interface.ts
@@ -251,7 +251,7 @@ export interface IndexSatellite {
     name: string
     port: number
     private_key_path: string
-    proxy_url: string
+    proxy_url: string | null
     remote_port: number
     sync_method: string
     timeout: number

--- a/src/app/modules/distribute_module/pages/satellites/satellites.interface.ts
+++ b/src/app/modules/distribute_module/pages/satellites/satellites.interface.ts
@@ -256,7 +256,7 @@ export interface IndexSatellite {
     sync_method: string
     timeout: number
     timezone: string
-    url: string
+    url: string | null
     use_proxy: number
     use_timesync: number
     verify_certificate: number


### PR DESCRIPTION
* Use the server time and time zone from the existing API request.
* The url is potentially NULL, so we fix the type.
* If url may be NULL, we need to catch this case.
* Do the same for proxy_url